### PR TITLE
Mascp Thruster Control + Updated Action Trait

### DIFF
--- a/cargo.toml
+++ b/cargo.toml
@@ -5,6 +5,5 @@ members = [
     "drivers/bme680",   
     "drivers/bmi088",   
     "drivers/pca9685",  
-    "drivers/ms5837",   
-    "murex-util"        
+    "drivers/ms5837",    
 ]

--- a/exp-aquatic/Cargo.toml
+++ b/exp-aquatic/Cargo.toml
@@ -19,6 +19,7 @@ name = "aquatic"
 path = "src/lib.rs"
 
 [dependencies]
+anyhow = "1.0.75"
 async-trait = "0.1.73"
 embedded-hal = "0.2.7"
 enum_dispatch = "0.3.12"

--- a/exp-aquatic/src/actions/mod.rs
+++ b/exp-aquatic/src/actions/mod.rs
@@ -4,5 +4,5 @@ mod system;
 use crate::rov::Rov;
 
 pub trait Action {
-    fn exec(&self, rov: &mut Rov);
+    fn exec(self, rov: &mut Rov);
 }

--- a/exp-aquatic/src/actions/mod.rs
+++ b/exp-aquatic/src/actions/mod.rs
@@ -4,5 +4,5 @@ mod system;
 use crate::rov::Rov;
 
 pub trait Action {
-    fn exec(&self, rov: Rov);
+    fn exec(&self, rov: &mut Rov);
 }

--- a/exp-aquatic/src/actions/movement.rs
+++ b/exp-aquatic/src/actions/movement.rs
@@ -3,70 +3,70 @@ use crate::rov::Rov;
 
 struct MoveToHeading(f32);
 impl Action for MoveToHeading {
-    fn exec(&self, rov: &mut Rov) {
+    fn exec(self, rov: &mut Rov) {
         todo!()
     }
 }
 
 struct MoveToDepth(f32);
 impl Action for MoveToDepth {
-    fn exec(&self, rov: &mut Rov) {
+    fn exec(self, rov: &mut Rov) {
         todo!()
     }
 }
 
 struct MoveToPosition(f32, f32, f32);
 impl Action for MoveToPosition {
-    fn exec(&self, rov: &mut Rov) {
+    fn exec(self, rov: &mut Rov) {
         todo!()
     }
 }
 
 struct MoveToRelativeHeading(f32);
 impl Action for MoveToRelativeHeading {
-    fn exec(&self, rov: &mut Rov) {
+    fn exec(self, rov: &mut Rov) {
         todo!()
     }
 }
 
 struct MoveToRelativeDepth(f32);
 impl Action for MoveToRelativeDepth {
-    fn exec(&self, rov: &mut Rov) {
+    fn exec(self, rov: &mut Rov) {
         todo!()
     }
 }
 
 struct MoveToRelativePosition(f32, f32, f32);
 impl Action for MoveToRelativePosition {
-    fn exec(&self, rov: &mut Rov) {
+    fn exec(self, rov: &mut Rov) {
         todo!()
     }
 }
 
 struct ThrusterControl(usize, f32);
 impl Action for ThrusterControl {
-    fn exec(&self, rov: &mut Rov) {
+    fn exec(self, rov: &mut Rov) {
         todo!()
     }
 }
 
 struct Resurface();
 impl Action for Resurface {
-    fn exec(&self, rov: &mut Rov) {
+    fn exec(self, rov: &mut Rov) {
         todo!()
     }
 }
 
 struct EmergencySurface();
 impl Action for EmergencySurface {
-    fn exec(&self, rov: &mut Rov) {
+    fn exec(self, rov: &mut Rov) {
         todo!()
     }
 }
 
 struct EmergencyStop();
 impl Action for EmergencyStop {
-    fn exec(&self, rov: &mut Rov) {
+    fn exec(self, rov: &mut Rov) {
         for i in 0..6 {
             rov.set_thruster(i, 0f32);
         }
@@ -75,7 +75,7 @@ impl Action for EmergencyStop {
 
 struct ToggleStabilityControl(bool);
 impl Action for ToggleStabilityControl {
-    fn exec(&self, rov: &mut Rov) {
+    fn exec(self, rov: &mut Rov) {
         todo!()
     }
 }

--- a/exp-aquatic/src/actions/movement.rs
+++ b/exp-aquatic/src/actions/movement.rs
@@ -68,7 +68,7 @@ struct EmergencyStop();
 impl Action for EmergencyStop {
     fn exec(&self, rov: &mut Rov) {
         for i in 0..6 {
-            rov.set_thruster(i, 0);
+            rov.set_thruster(i, 0f32);
         }
     }
 }

--- a/exp-aquatic/src/actions/movement.rs
+++ b/exp-aquatic/src/actions/movement.rs
@@ -3,70 +3,70 @@ use crate::rov::Rov;
 
 struct MoveToHeading(f32);
 impl Action for MoveToHeading {
-    fn exec(&self, rov: Rov) {
+    fn exec(&self, rov: &mut Rov) {
         todo!()
     }
 }
 
 struct MoveToDepth(f32);
 impl Action for MoveToDepth {
-    fn exec(&self, rov: Rov) {
+    fn exec(&self, rov: &mut Rov) {
         todo!()
     }
 }
 
 struct MoveToPosition(f32, f32, f32);
 impl Action for MoveToPosition {
-    fn exec(&self, rov: Rov) {
+    fn exec(&self, rov: &mut Rov) {
         todo!()
     }
 }
 
 struct MoveToRelativeHeading(f32);
 impl Action for MoveToRelativeHeading {
-    fn exec(&self, rov: Rov) {
+    fn exec(&self, rov: &mut Rov) {
         todo!()
     }
 }
 
 struct MoveToRelativeDepth(f32);
 impl Action for MoveToRelativeDepth {
-    fn exec(&self, rov: Rov) {
+    fn exec(&self, rov: &mut Rov) {
         todo!()
     }
 }
 
 struct MoveToRelativePosition(f32, f32, f32);
 impl Action for MoveToRelativePosition {
-    fn exec(&self, rov: Rov) {
+    fn exec(&self, rov: &mut Rov) {
         todo!()
     }
 }
 
 struct ThrusterControl(usize, f32);
 impl Action for ThrusterControl {
-    fn exec(&self, rov: Rov) {
+    fn exec(&self, rov: &mut Rov) {
         todo!()
     }
 }
 
 struct Resurface();
 impl Action for Resurface {
-    fn exec(&self, rov: Rov) {
+    fn exec(&self, rov: &mut Rov) {
         todo!()
     }
 }
 
 struct EmergencySurface();
 impl Action for EmergencySurface {
-    fn exec(&self, rov: Rov) {
+    fn exec(&self, rov: &mut Rov) {
         todo!()
     }
 }
 
 struct EmergencyStop();
 impl Action for EmergencyStop {
-    fn exec(&self, rov: Rov) {
+    fn exec(&self, rov: &mut Rov) {
         for i in 0..6 {
             rov.set_thruster(i, 0);
         }
@@ -75,7 +75,7 @@ impl Action for EmergencyStop {
 
 struct ToggleStabilityControl(bool);
 impl Action for ToggleStabilityControl {
-    fn exec(&self, rov: Rov) {
+    fn exec(&self, rov: &mut Rov) {
         todo!()
     }
 }

--- a/exp-aquatic/src/actions/system.rs
+++ b/exp-aquatic/src/actions/system.rs
@@ -3,34 +3,34 @@ use crate::rov::Rov;
 
 struct Reboot();
 impl Action for Reboot {
-    fn exec(&self, rov: &mut Rov) {
+    fn exec(self, rov: &mut Rov) {
         todo!()
     }
 }
 
 struct Shutdown();
 impl Action for Shutdown {
-    fn exec(&self, rov: &mut Rov) {
+    fn exec(self, rov: &mut Rov) {
         todo!()
     }
 }
 
 struct SystemReport();
 impl Action for SystemReport {
-    fn exec(&self, rov: &mut Rov) {
+    fn exec(self, rov: &mut Rov) {
     }
 }
 
 struct LeakReport();
 impl Action for LeakReport {
-    fn exec(&self, rov: &mut Rov) {
+    fn exec(self, rov: &mut Rov) {
         todo!()
     }
 }
 
 struct CallibrateSensors();
 impl Action for CallibrateSensors {
-    fn exec(&self, rov: &mut Rov) {
+    fn exec(self, rov: &mut Rov) {
         todo!()
     }
 }

--- a/exp-aquatic/src/actions/system.rs
+++ b/exp-aquatic/src/actions/system.rs
@@ -3,34 +3,34 @@ use crate::rov::Rov;
 
 struct Reboot();
 impl Action for Reboot {
-    fn exec(&self, rov: Rov) {
+    fn exec(&self, rov: &mut Rov) {
         todo!()
     }
 }
 
 struct Shutdown();
 impl Action for Shutdown {
-    fn exec(&self, rov: Rov) {
+    fn exec(&self, rov: &mut Rov) {
         todo!()
     }
 }
 
 struct SystemReport();
 impl Action for SystemReport {
-    fn exec(&self, rov: Rov) {
+    fn exec(&self, rov: &mut Rov) {
     }
 }
 
 struct LeakReport();
 impl Action for LeakReport {
-    fn exec(&self, rov: Rov) {
+    fn exec(&self, rov: &mut Rov) {
         todo!()
     }
 }
 
 struct CallibrateSensors();
 impl Action for CallibrateSensors {
-    fn exec(&self, rov: Rov) {
+    fn exec(&self, rov: &mut Rov) {
         todo!()
     }
 }

--- a/exp-aquatic/src/rov.rs
+++ b/exp-aquatic/src/rov.rs
@@ -1,5 +1,10 @@
 use linux_embedded_hal::{I2cdev, Spidev};
-use rppal::uart::Uart;
+use rppal::uart::{Uart, Parity};
+use anyhow::{Result, bail};
+use log::{trace, info, warn, error, debug};
+
+
+use std::time::Duration;
 
 pub struct Rov {
     i2c: I2cdev,
@@ -7,7 +12,7 @@ pub struct Rov {
     uart: Uart,
 
     pub thrusts: (f32, f32, f32, f32, f32, f32), // (front, back, left, right, top, bottom)
-    
+
     pub acceleration: (f32, f32, f32), // (x, y, z)
     pub velocity: (f32, f32, f32), // (x, y, z)
     pub position: (f32, f32, f32), // (x, y, z)
@@ -29,6 +34,17 @@ pub struct Rov {
 
 impl Rov {
     pub fn new() -> Self {
+        // TODO: Initialize I2C, SPI, and UART
+        // TODO: Remove .unwrap() calls and do propper error handling
+        let mut uart = Uart::new(
+            115_200, 
+            Parity::None, 
+            8, 
+            1)
+            .unwrap();
+
+        uart.set_read_mode(1, Duration::default()).unwrap();
+        uart.set_write_mode(true).unwrap();
         todo!()
     }
 
@@ -72,7 +88,62 @@ impl Rov {
         todo!()
     }
 
-    pub(crate) fn set_thruster(&self, thruster: usize, thrust: f32) {
-        todo!()
+    /// Sets the thrust of a given thruster using MASCP
+    /// 
+    /// # Arguments
+    ///    * `thruster` - The thruster to set the thrust of
+    ///    * `thrust` - The thrust to set the thruster to (-1.0 - 1.0)
+    /// 
+    /// # Returns
+    ///   * `Result<()>` - Ok if the thruster was set successfully, otherwise an error
+    pub(crate) fn set_thruster(&mut self, thruster: usize, thrust: f32) -> Result<()>  {
+        // TODO: Clarify structure for M[3] and M[4]
+        // MASCP Thruster Write
+        // M[0] = MASCP_THRUSTER_WRITE_INSTRUCTION
+        // M[1] = THRUSTER_SELECT = 0x00 - 0x05 (Thruster 0 - 5)
+        // M[2] = POSITIVE_THRUST = 0x00 - 0xFF (Thrust 0 - 255)
+        // M[3] = NEGATIVE_THRUST = 0x00 - 0xFF (Thrust 0 - 255)
+        // TODO: M[3] = INTERPOLATION_TIME
+        // TODO: M[4] = INTERPOLATION_FUNCTION_SELECT
+        // M[5-8] = 0xFF (Padding, later possibly checksum)
+
+        // Check if a valid thruster is being selected
+        if thruster > 5 || thruster < 0 {
+            warn!(target: "thruster_events", "Thruster `{}` is out of range", thruster);
+            bail!("Invalid thruster selected");
+        }
+        
+        // clamp thrust value between 0 and 1, then scale to 0 - 255
+        let thrust = thrust.max(-1.0).min(1.0) * 255.0;
+        trace!(target: "thruster_events", "Setting thruster {} to {}", thruster, thrust);
+        
+        // Send thruster command
+        let msg = [
+            0x00, 
+            thruster as u8, 
+            thrust as u8,           // Positive thrust
+            (-thrust) as u8,        // Negative thrust
+            0x00,                   // TBD interpolation time
+            0x00,                   // TBD interpolation function
+            0xFF,                   // Padding
+            0xFF,                   // Padding
+        ];
+        self.uart.write(&msg);
+        trace!(target: "thruster_events", "Sending MASCP thruster command payload");
+
+        // Validate thruster
+        let mut buffer = [0u8; 8];
+        // buffer [0] should be MASCP Thruster Write Response
+        // buffer [1-5] should be equivalent to the message
+        // buffer [6-7] should be 0x00
+        // TODO: Do additional checks as necessary, even these check is probably overkill
+        self.uart.read(&mut buffer);
+        if buffer[0] != 0x01 || // MASCP Thruster Write Response
+            buffer[6] != 0x00 || // ESC Padding is 0x00
+            buffer[7] != 0x00   // ESC Padding is 0x00
+        {
+            bail!("Thruster write failed")
+        }
+        Ok(())
     }
 }


### PR DESCRIPTION
- Implemented basic MASCP thruster control, specifics might change at later date but outlines overall structure of an MASCP transaction (sending data and validation).
- Updated Action trait so that it consumes self and takes mutable reference to `Rov` instead of taking reference to self and consuming Rov. The previous implementation was problematic since the Rov variable would be deallocated at the end of the actions execution and the action would still be "executable" from the point of view of the compiler. Changing the function signature addresses both of these issues.